### PR TITLE
Add development environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project Overview
+This is the **plus-ui** frontend for the RuoYi-Vue-Plus multi-tenant admin management system, built with Vue 3 + TypeScript + Element Plus + Vite. It is a frontend-only repo; the Java/Spring Boot backend is a separate project.
+
+### Running Services
+- **Dev server**: `npm run dev` — starts Vite on port 80, proxies `/dev-api` to `http://localhost:8080` (backend)
+- Port 80 requires `sudo sysctl -w net.ipv4.ip_unprivileged_port_start=0` before starting
+
+### Scripts Reference (see `package.json`)
+| Command | Purpose |
+|---|---|
+| `npm run dev` | Start Vite dev server (port 80) |
+| `npm run build:prod` | Production build |
+| `npm run lint:eslint` | Run ESLint |
+| `npm run lint:eslint:fix` | Run ESLint with auto-fix |
+| `npm run prettier` | Format all files with Prettier |
+
+### Known Issues
+- `npm run build:prod` fails due to a pre-existing template error in `src/views/docman/archive/index.vue` (invalid end tag). The dev server is unaffected.
+- ESLint reports many pre-existing Prettier formatting violations.
+
+### Backend Dependency
+The frontend proxies all API calls (`/dev-api`) to `http://localhost:8080`. Without the backend, the login page loads but login/API calls will fail. The backend is the separate [RuoYi-Vue-Plus](https://gitee.com/dromara/RuoYi-Vue-Plus) Java project.
+
+### Testing
+- `vitest` is listed in devDependencies but no test files or `vitest.config.ts` exist in the repo.
+- Lint check: `npm run lint:eslint`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this codebase.

### What's included

- Project overview and architecture context
- Development scripts reference
- Port 80 binding workaround (`sysctl` for unprivileged port access)
- Known issues documentation (pre-existing build error, ESLint violations)
- Backend dependency notes
- Testing status

### Environment Setup Verified

| Check | Result |
|---|---|
| Node.js >=20.15.0 | v22.22.1 |
| `npm install` | 558 packages installed |
| `npm run lint:eslint` | Works (pre-existing formatting errors) |
| `npm run dev` | Vite dev server running on port 80 |
| `npm run build:prod` | Fails due to pre-existing template error in `src/views/docman/archive/index.vue` |
| Browser demo | Login page renders and form validation works |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27d8645d-72b3-4a3c-8ff2-c6ebb58674ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27d8645d-72b3-4a3c-8ff2-c6ebb58674ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AGENTS.md` with Cursor Cloud setup for the `plus-ui` Vue 3 frontend. Covers running Vite on port 80 with a `sysctl` workaround, key npm scripts, `/dev-api` proxy to `http://localhost:8080`, and current build/lint caveats.

<sup>Written for commit 0e9053d0bdfa82cb008f292a3ff990c48e39ab82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

